### PR TITLE
Add curl timeouts to prevent hanging requests

### DIFF
--- a/src/LibrejaClient.php
+++ b/src/LibrejaClient.php
@@ -95,6 +95,8 @@ class LibrejaClient {
     $curl->setOpt(CURLOPT_HTTPHEADER, $this->serializeHeaders($formattedHeaders));
     $curl->setOpt(CURLOPT_RETURNTRANSFER, 1);
     $curl->setOpt(CURLOPT_HEADER, 1);
+    $curl->setOpt(CURLOPT_CONNECTTIMEOUT, 10);
+    $curl->setOpt(CURLOPT_TIMEOUT, 30);
 
     if (!empty($httpRequest->data) && isset($httpRequest->body)) {
       if (isset($formattedHeaders['content-type']) && $formattedHeaders['content-type'] == 'application/json') {


### PR DESCRIPTION
Add CURLOPT_CONNECTTIMEOUT (10s) and CURLOPT_TIMEOUT (30s) to all API requests. Without these, a slow or unresponsive API causes PHP workers to hang indefinitely (up to PHP's default timeout).