### PR TITLE
Fix ArticleMultiAvailable to use POST instead of PUT

### DIFF
--- a/src/Resource/Article/ArticleMultiAvailable.php
+++ b/src/Resource/Article/ArticleMultiAvailable.php
@@ -2,12 +2,12 @@
 
 namespace Factorial\Libreja\Resource\Article;
 
-use Factorial\Libreja\Http\HttpRequestPut;
+use Factorial\Libreja\Http\HttpRequestPost;
 
 /**
  * Check if multi articles are available.
  */
-class ArticleMultiAvailable extends HttpRequestPut {
+class ArticleMultiAvailable extends HttpRequestPost {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
The /availability/article/multiple endpoint returns 405 Method Not Allowed for PUT requests. Changed to POST which is the correct method.